### PR TITLE
Fix building on linux

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -8,7 +8,7 @@ MAN=
 LDADD=-levent
 
 greu: greu.c gre.h gre.c Makefile.linux
-	gcc $(CFLAGS) $(LDADD) -o $(PROG) $(SRCS)
+	gcc $(CFLAGS) -o $(PROG) $(SRCS) $(LDADD)
 
 clean:
 	rm greu


### PR DESCRIPTION
Placement of dependencies in gcc command matters. Thus reference to event library should be after where it is used (that is greu.c)